### PR TITLE
Support plugins that provide datatip as react components.

### DIFF
--- a/lib/datatip-manager.js
+++ b/lib/datatip-manager.js
@@ -208,7 +208,11 @@ module.exports = class DatatipManager {
             this.dataTipMarkerDisposables.dispose();
           };
 
-          if (result && result.markedStrings.length > 0) {
+          if (result && result.component){
+            const dataTipView = new DataTipView({ component: result.component });
+            this.dataTipMarkerDisposables = this.mountDataTipWithMarker(activeEditor, result.range, position, dataTipView);
+          }
+          else if (result && result.markedStrings.length > 0) {
             let snippet, markedString;
             result.markedStrings.forEach(m => {
               switch(m.type) {

--- a/lib/datatip-view.js
+++ b/lib/datatip-view.js
@@ -1,6 +1,7 @@
 'use babel';
 /** @jsx etch.dom */
 
+const ReactDOMServer = require('react-dom/server')
 const etch = require('etch')
 const marked = require('marked')
 const createDOMPurify = require('dompurify')
@@ -103,6 +104,17 @@ class MarkdownView {
   }
 }
 
+class ReactComponentView {
+  constructor({component}) {
+    this.rootElement = document.createElement('span')
+    this.rootElement.innerHTML = domPurify.sanitize(ReactDOMServer.renderToStaticMarkup(component()))
+  }
+
+  get element() {
+    return this.rootElement
+  }
+}
+
 module.exports = class DataTipView {
   // Required: Define an ordinary constructor to initialize your component.
   constructor (properties) {
@@ -113,6 +125,7 @@ module.exports = class DataTipView {
   render() {
     return (
       <div className="datatip-element">
+        <ReactComponentView component={this.properties.component} />
         <SnippetView snippet={this.properties.snippet} />
         <MarkdownView markedString={this.properties.markedString} />
       </div>

--- a/lib/datatip-view.js
+++ b/lib/datatip-view.js
@@ -107,7 +107,9 @@ class MarkdownView {
 class ReactComponentView {
   constructor({component}) {
     this.rootElement = document.createElement('span')
-    this.rootElement.innerHTML = domPurify.sanitize(ReactDOMServer.renderToStaticMarkup(component()))
+    if (component) {
+      this.rootElement.innerHTML = domPurify.sanitize(ReactDOMServer.renderToStaticMarkup(component()))
+    }
   }
 
   get element() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "atom-ide-datatips",
+  "name": "atom-ide-datatip",
   "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
@@ -47,10 +47,68 @@
       "integrity": "sha1-gy9kifvodnaUWVmckUpnDsIpR+4=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "marked": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.2.tgz",
       "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
+      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.12.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
+      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.12.0"
+      }
+    },
+    "scheduler": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
+      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "vscode-jsonrpc": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "dompurify": "^1.0.8",
     "etch": "^0.14.0",
-    "marked": "^0.5.2"
+    "marked": "^0.5.2",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0"
   },
   "devDependencies": {
     "@types/atom": "^1.31.0",


### PR DESCRIPTION
Unfortunately, this requires bringing in react as a dependency. Thankfully, we can just generate static markup for the component and render the string without all the react stuff. Calling `sanitize` on the string is a bit redundant but I don't think it hurts.