### PR TITLE
render multiple markedStrings instead of only one

### DIFF
--- a/lib/datatip-manager.js
+++ b/lib/datatip-manager.js
@@ -206,20 +206,7 @@ module.exports = class DatatipManager {
             this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, result.range, position, dataTipView);
           }
           else if (result && result.markedStrings.length > 0) {
-            let snippet, markedString, grammar;
-            result.markedStrings.forEach(m => {
-              switch(m.type) {
-                case "snippet":
-                  snippet = m.value;
-                  grammar = m.grammar;
-                  break;
-                case "markdown":
-                  markedString = m.value;
-                  break;
-              }
-            });
-
-            const dataTipView = new DataTipView({ snippet: snippet, grammar: grammar, markedString: markedString });
+            const dataTipView = new DataTipView({ markedStrings: result.markedStrings });
             this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, result.range, position, dataTipView);
           }
         });

--- a/lib/datatip-view.js
+++ b/lib/datatip-view.js
@@ -144,21 +144,27 @@ module.exports = class DataTipView {
     else {
       return (
         <div className="datatip-element">
-          <SnippetView snippet={this.properties.snippet} grammar={this.properties.grammar} />
-          <MarkdownView markedString={this.properties.markedString} />
+          {this.properties.markedStrings.map((m, i) => {
+            switch (m.type) {
+              case "snippet":
+                return <SnippetView key={i} snippet={m.value} grammar={m.grammar} />;
+              case "markdown":
+                return <MarkdownView key={i} markedString={m.value} />;
+            }
+          })}
         </div>
       );
     }
   }
 
-  update (props, children) {
+  update(props, children) {
     // perform custom update logic here...
     // then call `etch.update`, which is async and returns a promise
     return etch.update(this)
   }
 
   // Optional: Destroy the component. Async/await syntax is pretty but optional.
-  async destroy () {
+  async destroy() {
     // call etch.destroy to remove the element and destroy child components
     await etch.destroy(this)
     // then perform custom teardown logic here...

--- a/styles/atom-ide-datatips-marked.less
+++ b/styles/atom-ide-datatips-marked.less
@@ -8,7 +8,6 @@
 .datatip-marked-container {
   color: @syntax-text-color;
   font-family: @font-family;
-  max-height: 300px;
   max-width: 750px;
   overflow: auto;
   padding: 8px;

--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -5,8 +5,7 @@
   background: @app-background-color;
   box-shadow: 0px 1px 4px 0px rgba(0,0,0,1);
   color: @syntax-text-color;
-  font-family: var(--editor-font-family);
-  font-size: var(--editor-font-size);
+  font-size: 1rem; // some themes set font sizes on the root node
   margin-top: -2px; // Compensate for shadow
   position: relative;
   white-space: normal;
@@ -29,6 +28,10 @@
   position: relative;
   max-width: 750px;
   transition: background-color 0.15s ease;
+  padding: 8px;
+  white-space: pre-wrap;
+  font-family: var(--editor-font-family);
+  font-size: var(--editor-font-size);
   &:hover {
     background-color: mix(@syntax-background-color, @syntax-selection-color, 50%);
   }


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/3003233/51445870-61d8fe00-1d0a-11e9-86b8-184b33c19b38.png)
(used just one `markdown` item with all the content in a big markdown)

After:
![image](https://user-images.githubusercontent.com/3003233/51445873-6998a280-1d0a-11e9-81d9-fd743a48342e.png)
(uses markdown, snippet and markdown to render this beauty)