### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 * text=auto eol=lf
 
 /spec export-ignore
-/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /screenshot.png export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+
+/spec export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/screenshot.png export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).

Reference: https://github.com/facebookarchive/atom-ide-ui/blob/master/.gitattributes