### PR TITLE
fix: do not show the datatip when the mouse is too far away from a token

### DIFF
--- a/lib/datatip-manager.js
+++ b/lib/datatip-manager.js
@@ -257,6 +257,22 @@ module.exports = class DatatipManager {
       const component = this.editorView.getComponent();
       // the screen position returned here is always capped to the max width of the text in this row
       const screenPosition = component.screenPositionForMouseEvent(evt);
+      // the coordinates below represent X and Y positions on the screen of where the mouse event
+      // occured and where the capped screenPosition is located
+      const coordinates = {
+        mouse: component.pixelPositionForMouseEvent(evt),
+        screen: component.pixelPositionForScreenPosition(screenPosition),
+      };
+      const distance = Math.abs(coordinates.mouse.left - coordinates.screen.left);
+
+      // If the distance between the coordinates is greater than the default character width, it
+      // means the mouse event occured quite far away from where the text ends on that row. Do not
+      // show the datatip in such situations and hide any existing datatips (the mouse moved more to
+      // the right, away from the actual text)
+      if (distance >= this.editor.getDefaultCharWidth()) {
+        return this.hideDataTip();
+      }
+
       const point = this.editor.bufferPositionForScreenPosition(screenPosition);
       if ((this.currentMarkerRange === null) ||
            (!this.currentMarkerRange.containsPoint(point))) {


### PR DESCRIPTION
When you move your mouse over a line which ends with something that could potentially trigger a datatip and the mouse is quite far away to the right from the actual token the datatip is shown as if you hovered your mouse over that token.

This fixes the behaviour so that the datatip is only shown when you move your mouse close enough horizontally to the token on the line. ❤️

> Directly inspired by Atom-IDE's handling of these edge cases:
>
> https://github.com/facebookarchive/nuclide/blob/master/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/DatatipManager.js#L79L94

## Video demos

It's `.mov` so I cannot add a nice preview here. 😢

### Before

[datatip-before.mov.zip](https://github.com/atom-ide-community/atom-ide-datatip/files/2970686/datatip-before.mov.zip)

### After

[datatip-after.mov.zip](https://github.com/atom-ide-community/atom-ide-datatip/files/2970687/datatip-after.mov.zip)