### PR TITLE
Fixed font-size and pre tag design

### DIFF
--- a/styles/atom-ide-datatips-marked.less
+++ b/styles/atom-ide-datatips-marked.less
@@ -8,7 +8,7 @@
 .datatip-marked-container {
   color: @syntax-text-color;
   font-family: var(--editor-font-family);
-  font-size: max(var(--editor-font-size), 0.9rem);
+  font-size: var(--editor-font-size);
   max-width: 800px;
   overflow: auto;
   padding: 8px;
@@ -25,6 +25,8 @@
 
   pre {
     font-family: var(--editor-font-family);
-    font-size: max(var(--editor-font-size), 0.9rem);
+    font-size: var(--editor-font-size);
+    margin-bottom: 8px;
+    border-radius: 0;
   }
 }

--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -12,6 +12,13 @@
   pointer-events: all;
   max-width: 800px;
   overflow: none;
+  
+  p {
+    margin-left: 8px;
+    margin-right: 8px;
+    
+    &:last-child { margin-bottom: 8px; }
+  }
 }
 
 .datatip-overlay {
@@ -30,7 +37,7 @@
   padding: 8px;
   white-space: pre-wrap;
   font-family: var(--editor-font-family);
-  font-size: max(var(--editor-font-size), 0.9rem);
+  font-size: var(--editor-font-size);
   &:hover {
     background-color: mix(@syntax-background-color, @syntax-selection-color, 50%);
   }


### PR DESCRIPTION
Since the release of the markdown service the `.datatip-element` design has changed. This pull requests reverts back to the previous design.

**Before (current implementation)**

<img width="860" alt="Screenshot 2019-03-17 at 18 01 15" src="https://user-images.githubusercontent.com/499192/54494873-16446a00-48df-11e9-8afc-bea08a3751a2.png">

**After (this pull request)**

<img width="890" alt="Screenshot 2019-03-17 at 17 56 40" src="https://user-images.githubusercontent.com/499192/54494862-0036a980-48df-11e9-9867-ae9119a5bcc8.png">

---

One thing I noted is that LESS `max` function can't handle values of different types. In the current implementation we're using both `px` and `rem`. I tried running this locally and got the following error:

```
ArgumentError: error evaluating function `max`: incompatible types in /Users/vincent/Desktop/styles.less on line 2, column 14:
1 body {
2   font-size: max(14px, 0.9rem);
3 }
```

I've updated to always default to the editor's current font size.