### PR TITLE
fix: removed datatip padding

### DIFF
--- a/styles/atom-ide-datatips-marked.less
+++ b/styles/atom-ide-datatips-marked.less
@@ -12,7 +12,6 @@
   max-width: 800px;
   max-height: 400px;
   overflow: auto;
-  padding: 8px;
   white-space: normal;
 
   // Avoid excess internal padding from markdown blocks.


### PR DESCRIPTION
This is a follow up from #28. Sorry for the inconvenience.