### PR TITLE
fix: use UI-font for markdown body strings

### DIFF
--- a/styles/atom-ide-datatips-marked.less
+++ b/styles/atom-ide-datatips-marked.less
@@ -7,8 +7,8 @@
 
 .datatip-marked-container {
   color: @syntax-text-color;
-  font-family: var(--editor-font-family);
-  font-size: var(--editor-font-size);
+  font-family: @font-family;
+  font-size: @font-size;
   max-height: 400px;
   max-width: 64em;
   overflow: auto;


### PR DESCRIPTION
Atom-IDE-UI's datatip used UI fonts for markdown body texts and looked neat.
atom-ide-datatip currently uses editor fonts for body texts and appears a little weird IMHO, and this patch fixes this.

### Overview

Before:
![Screenshot 2019-08-03 05 07 03](https://user-images.githubusercontent.com/40514306/62396105-2f5b6800-b5ad-11e9-9602-0ab0c81d9cb2.png)

After:
![Screenshot 2019-08-03 05 03 40](https://user-images.githubusercontent.com/40514306/62396110-33878580-b5ad-11e9-88d7-545abcd4374d.png)
