### PR TITLE
Change the style of the datatip to match other Atom popovers

### DIFF
--- a/lib/datatip-manager.js
+++ b/lib/datatip-manager.js
@@ -365,7 +365,7 @@ export class DataTipManager {
               containerClassName: "datatip-component-container",
               contentClassName: "datatip-component",
             },
-            className: `datatip-element ${this.glowClass}`,
+            className: `datatip-element select-list popover-list ${this.glowClass}`,
           })
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)
         } else if (datatip.markedStrings.length > 0) {
@@ -400,7 +400,7 @@ export class DataTipManager {
             }
           }
 
-          const dataTipView = new ViewContainer({ snippet, markdown, className: `datatip-element ${this.glowClass}` })
+          const dataTipView = new ViewContainer({ snippet, markdown, className: `datatip-element select-list popover-list ${this.glowClass}` })
 
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,9 @@ devDependencies:
   '@types/node': 14.14.2
   atom-jasmine3-test-runner: 5.1.4
   atom-languageclient: 1.0.0
-  babel-preset-atomic: 2.4.2_3b4728ed79b31306f6773a6f5aa888fa
+  babel-preset-atomic: 3.0.1_3b4728ed79b31306f6773a6f5aa888fa
   build-commit: 0.1.1
-  cross-env: 7.0.2
+  cross-env: 7.0.3
   eslint: 7.11.0
   eslint-config-atomic: 1.5.0_eslint@7.11.0
   npm-check-updates: 9.1.2
@@ -21,7 +21,7 @@ devDependencies:
   shx: 0.3.2
   tslib: 2.0.3
   typescript: 4.0.3
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@babel/cli/7.12.1_@babel+core@7.12.3:
     dependencies:
@@ -49,14 +49,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
-  /@babel/compat-data/7.11.0:
-    dependencies:
-      browserslist: 4.14.5
-      invariant: 2.2.4
-      semver: 5.7.1
+  /@babel/compat-data/7.12.7:
     dev: true
     resolution:
-      integrity: sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==
+      integrity: sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
   /@babel/core/7.11.6:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -121,81 +117,69 @@ packages:
       integrity: sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==
   /@babel/helper-annotate-as-pure/7.10.4:
     dependencies:
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.1
     dev: true
     resolution:
       integrity: sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
+  /@babel/helper-annotate-as-pure/7.12.10:
+    dependencies:
+      '@babel/types': 7.12.12
+    dev: true
+    resolution:
+      integrity: sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.11.4
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.12
     dev: true
     resolution:
       integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
-  /@babel/helper-builder-react-jsx-experimental/7.11.5:
+  /@babel/helper-compilation-targets/7.12.5_@babel+core@7.12.3:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-module-imports': 7.10.4
-      '@babel/types': 7.11.5
-    dev: true
-    resolution:
-      integrity: sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==
-  /@babel/helper-builder-react-jsx/7.10.4:
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/types': 7.11.5
-    dev: true
-    resolution:
-      integrity: sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==
-  /@babel/helper-compilation-targets/7.10.4_@babel+core@7.12.3:
-    dependencies:
-      '@babel/compat-data': 7.11.0
+      '@babel/compat-data': 7.12.7
       '@babel/core': 7.12.3
+      '@babel/helper-validator-option': 7.12.11
       browserslist: 4.14.5
-      invariant: 2.2.4
-      levenary: 1.1.1
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
-  /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.12.3:
+      integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
+  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-function-name': 7.10.4
-      '@babel/helper-member-expression-to-functions': 7.11.0
+      '@babel/helper-member-expression-to-functions': 7.12.1
       '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-replace-supers': 7.12.1
       '@babel/helper-split-export-declaration': 7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
-  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
+  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-regex': 7.10.5
+      '@babel/helper-annotate-as-pure': 7.12.10
       regexpu-core: 4.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+      integrity: sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==
   /@babel/helper-define-map/7.10.5:
     dependencies:
       '@babel/helper-function-name': 7.10.4
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.12
       lodash: 4.17.20
     dev: true
     resolution:
       integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==
   /@babel/helper-explode-assignable-expression/7.11.4:
     dependencies:
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.12
     dev: true
     resolution:
       integrity: sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==
@@ -215,7 +199,7 @@ packages:
       integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   /@babel/helper-hoist-variables/7.10.4:
     dependencies:
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.12
     dev: true
     resolution:
       integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
@@ -243,6 +227,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==
+  /@babel/helper-module-imports/7.12.5:
+    dependencies:
+      '@babel/types': 7.12.12
+    dev: true
+    resolution:
+      integrity: sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
   /@babel/helper-module-transforms/7.11.0:
     dependencies:
       '@babel/helper-module-imports': 7.10.4
@@ -279,21 +269,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
-  /@babel/helper-regex/7.10.5:
+  /@babel/helper-remap-async-to-generator/7.12.1:
     dependencies:
-      lodash: 4.17.20
-    dev: true
-    resolution:
-      integrity: sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==
-  /@babel/helper-remap-async-to-generator/7.11.4:
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-wrap-function': 7.10.4
-      '@babel/template': 7.10.4
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.12
     dev: true
     resolution:
-      integrity: sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==
+      integrity: sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==
   /@babel/helper-replace-supers/7.10.4:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.11.0
@@ -325,12 +308,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
-  /@babel/helper-skip-transparent-expression-wrappers/7.11.0:
+  /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
     dependencies:
-      '@babel/types': 7.11.5
+      '@babel/types': 7.12.1
     dev: true
     resolution:
-      integrity: sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
+      integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
   /@babel/helper-split-export-declaration/7.11.0:
     dependencies:
       '@babel/types': 7.12.1
@@ -341,12 +324,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+  /@babel/helper-validator-identifier/7.12.11:
+    dev: true
+    resolution:
+      integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+  /@babel/helper-validator-option/7.12.11:
+    dev: true
+    resolution:
+      integrity: sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==
   /@babel/helper-wrap-function/7.10.4:
     dependencies:
       '@babel/helper-function-name': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.11.5
-      '@babel/types': 7.11.5
+      '@babel/traverse': 7.12.1
+      '@babel/types': 7.12.1
     dev: true
     resolution:
       integrity: sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==
@@ -388,49 +379,49 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
-  /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.12.3:
+  /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-remap-async-to-generator': 7.11.4
+      '@babel/helper-remap-async-to-generator': 7.12.1
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
-  /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==
+  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.12.3
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
-  /@babel/plugin-proposal-decorators/7.10.5_@babel+core@7.12.3:
+      integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
+  /@babel/plugin-proposal-decorators/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.12.3
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-decorators': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-decorators': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==
-  /@babel/plugin-proposal-do-expressions/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-fhkE9lJYpw2mjHelBpM2zCbaA11aov2GJs7q4cFaXNrWx0H3bW58H9Esy2rdtYOghFBEYUDRIpvlgi+ZD+AvvQ==
+  /@babel/plugin-proposal-do-expressions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-do-expressions': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-do-expressions': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Gcc2wLVeMceRdP6m9tdDygP01lbUVmaQGBRoIRJZxzPfB5VTiUgmn1jGfORgqbEVgUpG0IQm/z4q5Y/qzG+8JQ==
-  /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-bpJ6Bfrzvdzb0vG6zBSNh3HLgFKh+S2CBpNmaLRjg2u7cNkzRPIqBjVURCmpG6pvPfKyxkizwbrXwpYtW3a9cw==
+  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -439,18 +430,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
-  /@babel/plugin-proposal-export-default-from/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
+  /@babel/plugin-proposal-export-default-from/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-export-default-from': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-export-default-from': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-G1l00VvDZ7Yk2yRlC5D8Ybvu3gmeHS3rCHoUYdjrqGYUtdeOBoRypnvDZ5KQqxyaiiGHWnVDeSEzA5F9ozItig==
-  /@babel/plugin-proposal-export-namespace-from/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-z5Q4Ke7j0AexQRfgUvnD+BdCSgpTEKnqQ3kskk2jWtOBulxICzd1X9BGt7kmWftxZ2W3++OZdt5gtmC8KLxdRQ==
+  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -459,29 +450,29 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
-  /@babel/plugin-proposal-function-bind/7.11.5_@babel+core@7.12.3:
+      integrity: sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==
+  /@babel/plugin-proposal-function-bind/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-function-bind': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-function-bind': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-gkCyUqJp6jRPdHFAYZxGal6d6Poj17G+6FGbyUcHKew2sccp5HVilTgnreYqTzDsY10Ys0ZVB/U2knTnnJdkUQ==
-  /@babel/plugin-proposal-function-sent/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-Nic0blOXoeyuDJZJNh7kEZMqQUHakiUyxfyFMUV0Sy7DQ+Du9R7cZCUgTLnqq7Bc0Yx0iKRSe5wTmRWLKwxxpA==
+  /@babel/plugin-proposal-function-sent/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-wrap-function': 7.10.4
-      '@babel/plugin-syntax-function-sent': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-function-sent': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-aBtve/DhQsVPAGnSDcgt33gF36rO0TK+KtHp9Hwtj3KwH+o1Cii9vfVVYeB9c6Jo1SXOgTRwRD7ljpTS0qbN8w==
-  /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-EXB01ACyNW0WCffP4ip40TH82X86+U0dakFZjyiMpoZ8NFmL5MMARzVBzy+Gg59B6vTgfvIhRHUhe6tNUw+vjw==
+  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -490,8 +481,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
-  /@babel/plugin-proposal-logical-assignment-operators/7.11.0_@babel+core@7.12.3:
+      integrity: sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==
+  /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -500,8 +491,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -510,8 +501,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
-  /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
+  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -520,19 +511,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
-  /@babel/plugin-proposal-object-rest-spread/7.11.0_@babel+core@7.12.3:
+      integrity: sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
+  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.3
-      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.12.3
+      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
-  /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
+  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -541,52 +532,52 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
-  /@babel/plugin-proposal-optional-chaining/7.11.0_@babel+core@7.12.3:
+      integrity: sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==
+  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+      '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
-  /@babel/plugin-proposal-pipeline-operator/7.10.5_@babel+core@7.12.3:
+      integrity: sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
+  /@babel/plugin-proposal-pipeline-operator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-pipeline-operator': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-pipeline-operator': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-tCpZ46KUAHgFoXsH593k9sX/ZKsNb4NlTGNif8PdlmkGbtYdbTQi6zNv8yibpRf+3sQFElOBLyNo3I5ZwVu90g==
-  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-iloNp4xu8YV8e/mZgGjePg9be1VkJSxQWIplRwgQtQPtF26ar3cHXL4sV8Fujlm2mm/Tu/WiA+FU+Fp7QVP7/g==
+  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.12.3
+      '@babel/helper-create-class-features-plugin': 7.12.1_@babel+core@7.12.3
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
-  /@babel/plugin-proposal-throw-expressions/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==
+  /@babel/plugin-proposal-throw-expressions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-throw-expressions': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-throw-expressions': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-m7K9duXeH/rko36i9G9seLOg2AVdeVTn65k8nnTxgozex0hkDSUr6cktJxTO7jElGEpmMz410pTs0Jn8+empxw==
-  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-kiWkKtm05K86C+T/nUazv+/Vxu93Aulrvof/ZrxVyGoUBVsVEWDrw9iChbe8tV+aPVQcjg4FQxKW3wUF7cRcpg==
+  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     engines:
@@ -594,7 +585,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+      integrity: sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -604,7 +595,7 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.12.3:
+  /@babel/plugin-syntax-class-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -612,8 +603,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
-  /@babel/plugin-syntax-decorators/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==
+  /@babel/plugin-syntax-decorators/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -621,8 +612,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==
-  /@babel/plugin-syntax-do-expressions/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==
+  /@babel/plugin-syntax-do-expressions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -630,7 +621,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-HyvaTg1aiwGo2I+Pu0nyurRMjIP7J89GpuZ2mcQ0fhO6Jt3BnyhEPbNJFG1hRE99NAPNfPYh93/7HO+GPVkTKg==
+      integrity: sha512-a9TknRXkzfetNjOWSWnPIG/Y7x+elzcmKng2Qpvh8QaqdPo0OABizTjco8YO8r5xZNQfE58YHq7lWR+PKwHyxg==
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -640,7 +631,7 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-export-default-from/7.10.4_@babel+core@7.12.3:
+  /@babel/plugin-syntax-export-default-from/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -648,7 +639,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-79V6r6Pgudz0RnuMGp5xidu6Z+bPFugh8/Q9eDHonmLp4wKFAZDwygJwYgCzuDu8lFA/sYyT+mc5y2wkd7bTXA==
+      integrity: sha512-dP5eGg6tHEkhnRD2/vRG/KJKRSg8gtxu2i+P/8/yFPJn/CfPU5G0/7Gks2i3M6IOVAPQekmsLN9LPsmXFFL4Uw==
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -658,7 +649,7 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
-  /@babel/plugin-syntax-flow/7.10.4_@babel+core@7.12.3:
+  /@babel/plugin-syntax-flow/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -666,8 +657,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
-  /@babel/plugin-syntax-function-bind/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-1lBLLmtxrwpm4VKmtVFselI/P3pX+G63fAtUUt6b2Nzgao77KNDwyuRt90Mj2/9pKobtt68FdvjfqohZjg/FCA==
+  /@babel/plugin-syntax-function-bind/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -675,8 +666,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-vF/K9yS0dpPNlT7mXSGhbdpb2f4DaLa/AYYbUqlxOggAug/oseIR1+LgAzwci4iJNlqWNmJ7aQ+llUMYjn9uhw==
-  /@babel/plugin-syntax-function-sent/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-YN14nxb0Q3/M7AUDnwnjFYpUylysfZ4KY/byhIz5PN7JyMJldjuUS+UmV7bOL6crQ0M69tuoevD/AlOveDeyMQ==
+  /@babel/plugin-syntax-function-sent/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -684,7 +675,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-dwElaRoDQhlVevbgKOlEUTe08QNJo4ZjWw3rqnMbEvH8NRJM+iPN2tTQtzyfNloXD8f3Jdiyf5Pn400B1U3SVA==
+      integrity: sha512-mtBQvNHcIzLnmQZhgzigzrgFzIe95WvBXJuTN0m4CvhDK0gRNQ2MC2AVSzB6w7VnVh/z5+0iHFcbfqKMlFwTkQ==
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -703,7 +694,7 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-jsx/7.10.4_@babel+core@7.12.3:
+  /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -711,7 +702,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
+      integrity: sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
@@ -766,7 +757,7 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-pipeline-operator/7.10.4_@babel+core@7.12.3:
+  /@babel/plugin-syntax-pipeline-operator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -774,8 +765,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-QOmXevisZebt9pBkMdDdXWg+fndB8dT/puwSKKu/1K3P4oBwmydN/4dX1hdrNvPHbw4xE+ocIoEus7c4eh7Igg==
-  /@babel/plugin-syntax-throw-expressions/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-NazCTl1P9Kp+790g7gDRQEvhU0+OYbZVsuW45ThfgVCdUyhtxzFJeFrzY6BX/u/NfFyXWbKAIl6wR0PhJWwyDA==
+  /@babel/plugin-syntax-throw-expressions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -783,8 +774,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Yac/4W71+JdAiOV3aLbnUUe2R0NZzNvdy5EqdauFnBQTxIXT58M89lOplIFVELTSus6PxFMjmbi2vXaJDiV/PQ==
-  /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-+8FLGK1PYYB7D8tU9U5zX23fnzkpxw4a7lAyyZbgk6b6bN0k2dft/xwcxIE+86i54wLJ83BaAboh2Ow6wf6jHw==
+  /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -792,8 +783,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
-  /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==
+  /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -801,28 +792,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
-  /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==
+  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-module-imports': 7.12.5
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-remap-async-to-generator': 7.11.4
+      '@babel/helper-remap-async-to-generator': 7.12.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
-  /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.12.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
-  /@babel/plugin-transform-block-scoping/7.11.1_@babel+core@7.12.3:
+      integrity: sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==
+  /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -830,24 +812,33 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
-  /@babel/plugin-transform-classes/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==
+  /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==
+  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.12.3:
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.12.10
       '@babel/helper-define-map': 7.10.5
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-replace-supers': 7.12.1
       '@babel/helper-split-export-declaration': 7.11.0
       globals: 11.12.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
-  /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==
+  /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -855,8 +846,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
-  /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==
+  /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -864,18 +855,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
-  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
+  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
-  /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==
+  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -883,8 +874,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
-  /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==
+  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
@@ -893,18 +884,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
-  /@babel/plugin-transform-flow-strip-types/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==
+  /@babel/plugin-transform-flow-strip-types/7.12.10_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-flow': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-flow': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
-  /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-0ti12wLTLeUIzu9U7kjqIn4MyOL7+Wibc7avsHhj4o1l5C0ATs8p2IMHrVYjm9t9wzhfEO6S3kxax0Rpdo8LTg==
+  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -912,8 +903,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
-  /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
+  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-function-name': 7.10.4
@@ -922,8 +913,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
-  /@babel/plugin-transform-literals/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==
+  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -931,8 +922,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
-  /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==
+  /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -940,62 +931,63 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
-  /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.12.3:
+      integrity: sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==
+  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-module-transforms': 7.12.1
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
-  /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==
+  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-module-transforms': 7.12.1
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-simple-access': 7.10.4
+      '@babel/helper-simple-access': 7.12.1
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
-  /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.12.3:
+      integrity: sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
+  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-module-transforms': 7.12.1
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-validator-identifier': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
-  /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==
+  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-module-transforms': 7.12.1
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==
+  /@babel/plugin-transform-named-capturing-groups-regex/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
-  /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==
+  /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1003,28 +995,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
-  /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==
+  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-replace-supers': 7.12.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
-  /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.12.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-get-function-arity': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
-  /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==
+  /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1032,8 +1014,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
-  /@babel/plugin-transform-react-display-name/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
+  /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1041,51 +1023,39 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
-  /@babel/plugin-transform-react-jsx-development/7.11.5_@babel+core@7.12.3:
+      integrity: sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==
+  /@babel/plugin-transform-react-display-name/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-builder-react-jsx-experimental': 7.11.5
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-cImAmIlKJ84sDmpQzm4/0q/2xrXlDezQoixy3qoz1NJeZL/8PRon6xZtluvr4H4FzwlDGI5tCcFupMnXGtr+qw==
-  /@babel/plugin-transform-react-jsx-self/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-cAzB+UzBIrekfYxyLlFqf/OagTvHLcVBb5vpouzkYkBclRPraiygVnafvAoipErZLI8ANv8Ecn6E/m5qPXD26w==
+  /@babel/plugin-transform-react-jsx-development/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
-  /@babel/plugin-transform-react-jsx-source/7.10.5_@babel+core@7.12.3:
+      integrity: sha512-i1AxnKxHeMxUaWVXQOSIco4tvVvvCxMSfeBMnMM06mpaJt3g+MpxYQQrDfojUQldP1xxraPSJYSMEljoWM/dCg==
+  /@babel/plugin-transform-react-jsx/7.12.12_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.12.10
+      '@babel/helper-module-imports': 7.12.5
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-jsx': 7.12.1_@babel+core@7.12.3
+      '@babel/types': 7.12.12
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
-  /@babel/plugin-transform-react-jsx/7.10.4_@babel+core@7.12.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-builder-react-jsx': 7.10.4
-      '@babel/helper-builder-react-jsx-experimental': 7.11.5
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.12.3
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
-  /@babel/plugin-transform-react-pure-annotations/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==
+  /@babel/plugin-transform-react-pure-annotations/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-annotate-as-pure': 7.10.4
@@ -1094,8 +1064,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
-  /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==
+  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       regenerator-transform: 0.14.5
@@ -1103,8 +1073,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
-  /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==
+  /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1112,8 +1082,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
-  /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==
+  /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1121,38 +1091,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
-  /@babel/plugin-transform-spread/7.11.0_@babel+core@7.12.3:
+      integrity: sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==
+  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+      '@babel/helper-skip-transparent-expression-wrappers': 7.12.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
-  /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.12.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-regex': 7.10.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
-  /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.12.3:
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
-  /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==
+  /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1160,8 +1110,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
-  /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
+  /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
@@ -1169,39 +1119,58 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
-  /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==
+  /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.12.3
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
-  /@babel/preset-env/7.11.5_@babel+core@7.12.3:
+      integrity: sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==
+  /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.12.3:
     dependencies:
-      '@babel/compat-data': 7.11.0
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.12.3
-      '@babel/helper-module-imports': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-proposal-async-generator-functions': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0_@babel+core@7.12.3
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-object-rest-spread': 7.11.0_@babel+core@7.12.3
-      '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.12.3
-      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.12.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==
+  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.12.3:
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-create-regexp-features-plugin': 7.12.7_@babel+core@7.12.3
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==
+  /@babel/preset-env/7.12.10_@babel+core@7.12.3:
+    dependencies:
+      '@babel/compat-data': 7.12.7
+      '@babel/core': 7.12.3
+      '@babel/helper-compilation-targets': 7.12.5_@babel+core@7.12.3
+      '@babel/helper-module-imports': 7.12.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-validator-option': 7.12.11
+      '@babel/plugin-proposal-async-generator-functions': 7.12.12_@babel+core@7.12.3
+      '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-dynamic-import': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-export-namespace-from': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-json-strings': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-logical-assignment-operators': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-numeric-separator': 7.12.7_@babel+core@7.12.3
+      '@babel/plugin-proposal-object-rest-spread': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-optional-catch-binding': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-optional-chaining': 7.12.7_@babel+core@7.12.3
+      '@babel/plugin-proposal-private-methods': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.12.3
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.12.3
-      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-class-properties': 7.12.1_@babel+core@7.12.3
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.3
       '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.12.3
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.12.3
@@ -1211,89 +1180,84 @@ packages:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.3
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.12.3
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.12.3
-      '@babel/plugin-syntax-top-level-await': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-arrow-functions': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-async-to-generator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-block-scoped-functions': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-block-scoping': 7.11.1_@babel+core@7.12.3
-      '@babel/plugin-transform-classes': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-computed-properties': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-destructuring': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-duplicate-keys': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-exponentiation-operator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-for-of': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-function-name': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-literals': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-member-expression-literals': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-modules-amd': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-modules-systemjs': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-transform-modules-umd': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-new-target': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-object-super': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-transform-property-literals': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-spread': 7.11.0_@babel+core@7.12.3
-      '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-template-literals': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-syntax-top-level-await': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-arrow-functions': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-async-to-generator': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-block-scoped-functions': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-block-scoping': 7.12.12_@babel+core@7.12.3
+      '@babel/plugin-transform-classes': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-computed-properties': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-destructuring': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-duplicate-keys': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-exponentiation-operator': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-for-of': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-function-name': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-literals': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-member-expression-literals': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-modules-amd': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-modules-commonjs': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-modules-systemjs': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-modules-umd': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-new-target': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-object-super': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-parameters': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-property-literals': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-regenerator': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-reserved-words': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-shorthand-properties': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-spread': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-sticky-regex': 7.12.7_@babel+core@7.12.3
+      '@babel/plugin-transform-template-literals': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-typeof-symbol': 7.12.10_@babel+core@7.12.3
+      '@babel/plugin-transform-unicode-escapes': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-unicode-regex': 7.12.1_@babel+core@7.12.3
       '@babel/preset-modules': 0.1.4_@babel+core@7.12.3
-      '@babel/types': 7.11.5
-      browserslist: 4.14.5
-      core-js-compat: 3.6.5
-      invariant: 2.2.4
-      levenary: 1.1.1
+      '@babel/types': 7.12.12
+      core-js-compat: 3.8.3
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==
-  /@babel/preset-flow/7.10.4_@babel+core@7.12.3:
+      integrity: sha512-Gz9hnBT/tGeTE2DBNDkD7BiWRELZt+8lSysHuDwmYXUIvtwZl0zI+D6mZgXZX0u8YBlLS4tmai9ONNY9tjRgRA==
+  /@babel/preset-flow/7.12.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-flow-strip-types': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-transform-flow-strip-types': 7.12.10_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==
+      integrity: sha512-UAoyMdioAhM6H99qPoKvpHMzxmNVXno8GYU/7vZmGaHk6/KqfDYL1W0NxszVbJ2EP271b7e6Ox+Vk2A9QsB3Sw==
   /@babel/preset-modules/0.1.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.12.3
-      '@babel/types': 7.11.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-dotall-regex': 7.12.1_@babel+core@7.12.3
+      '@babel/types': 7.12.12
       esutils: 2.0.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
-  /@babel/preset-react/7.10.4_@babel+core@7.12.3:
+  /@babel/preset-react/7.12.10_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-react-display-name': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-react-jsx': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-react-jsx-development': 7.11.5_@babel+core@7.12.3
-      '@babel/plugin-transform-react-jsx-self': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-transform-react-jsx-source': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-transform-react-pure-annotations': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-transform-react-display-name': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-transform-react-jsx': 7.12.12_@babel+core@7.12.3
+      '@babel/plugin-transform-react-jsx-development': 7.12.12_@babel+core@7.12.3
+      '@babel/plugin-transform-react-pure-annotations': 7.12.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==
+      integrity: sha512-vtQNjaHRl4DUpp+t+g4wvTHsLQuye+n0H/wsXIZRn69oz/fvNC7gQ4IK73zGJBaxvHoxElDvnYCthMcT7uzFoQ==
   /@babel/runtime-corejs3/7.11.2:
     dependencies:
       core-js-pure: 3.6.5
@@ -1359,6 +1323,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
+  /@babel/types/7.12.12:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.12.11
+      lodash: 4.17.20
+      to-fast-properties: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
   /@eslint/eslintrc/0.1.3:
     dependencies:
       ajv: 6.12.5
@@ -2144,47 +2116,49 @@ packages:
       npm: '>=6'
     resolution:
       integrity: sha512-8DqJq6/LPUjSZ0Qq6bVIFpsj2flCEE0Cbnbut9TvGU6jP9g3dOWEXtQ/sdvsA9d6souza8eNGh04WRXpuH9ThA==
-  /babel-plugin-transform-not-strict/0.2.1_@babel+core@7.12.3:
+  /babel-plugin-transform-not-strict/0.3.1_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
     dev: true
     peerDependencies:
-      '@babel/core': 7.11.6
+      '@babel/core': ^7
     resolution:
-      integrity: sha512-I0ZFdQyEa2vbbqlTt3D9idTeoSk5GGRdVi2PD4o0yNgFrTyesoS5OzPJXDDwXmXiiZWNTzQkmaybpuImCpKXDQ==
-  /babel-preset-atomic/2.4.2_3b4728ed79b31306f6773a6f5aa888fa:
+      integrity: sha512-1m9IY7AYL84Pj0UWpWizDdI/uuKFp+UjBqHBuSsJSlf8//yK3RfQXWVxVXEeYNgUPa36bCIFeVIeE2cFuWxJGA==
+  /babel-preset-atomic/3.0.1_3b4728ed79b31306f6773a6f5aa888fa:
     dependencies:
       '@babel/cli': 7.12.1_@babel+core@7.12.3
       '@babel/core': 7.12.3
-      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-decorators': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-proposal-do-expressions': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-export-default-from': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-function-bind': 7.11.5_@babel+core@7.12.3
-      '@babel/plugin-proposal-function-sent': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0_@babel+core@7.12.3
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.12.3
-      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.12.3
-      '@babel/plugin-proposal-pipeline-operator': 7.10.5_@babel+core@7.12.3
-      '@babel/plugin-proposal-throw-expressions': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-proposal-class-properties': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-decorators': 7.12.12_@babel+core@7.12.3
+      '@babel/plugin-proposal-do-expressions': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-export-default-from': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-export-namespace-from': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-function-bind': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-function-sent': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-json-strings': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-logical-assignment-operators': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-numeric-separator': 7.12.7_@babel+core@7.12.3
+      '@babel/plugin-proposal-optional-chaining': 7.12.7_@babel+core@7.12.3
+      '@babel/plugin-proposal-pipeline-operator': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-private-methods': 7.12.1_@babel+core@7.12.3
+      '@babel/plugin-proposal-throw-expressions': 7.12.1_@babel+core@7.12.3
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.12.3
       '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.12.3
-      '@babel/preset-env': 7.11.5_@babel+core@7.12.3
-      '@babel/preset-flow': 7.10.4_@babel+core@7.12.3
-      '@babel/preset-react': 7.10.4_@babel+core@7.12.3
+      '@babel/plugin-transform-reserved-words': 7.12.1_@babel+core@7.12.3
+      '@babel/preset-env': 7.12.10_@babel+core@7.12.3
+      '@babel/preset-flow': 7.12.1_@babel+core@7.12.3
+      '@babel/preset-react': 7.12.10_@babel+core@7.12.3
       babel-plugin-add-module-exports: 1.0.4
       babel-plugin-codegen: 4.0.1
       babel-plugin-preval: 5.0.0
-      babel-plugin-transform-not-strict: 0.2.1_@babel+core@7.12.3
+      babel-plugin-transform-not-strict: 0.3.1_@babel+core@7.12.3
     dev: true
     peerDependencies:
-      '@babel/cli': 7.11.6
-      '@babel/core': 7.11.6
+      '@babel/cli': ^7
+      '@babel/core': ^7
     resolution:
-      integrity: sha512-7rKelxkGHZBvnuKh/QrWU+AxliBMr/8dwb8k1tsa08ZsYhN1Ae01mYI4v75w3Ak2A1CVs38ceE0EOqzcVKTtEw==
+      integrity: sha512-Bx1bdyIiFH1dZKMqbixUa5/8AvubVT9xsMl2x8GEKrp2EliyzsjzY+8Gt3ha2MO7gvosHc2LQ7nOXd2aMdADVQ==
   /babel-runtime/6.26.0:
     dependencies:
       core-js: 2.6.11
@@ -2332,6 +2306,19 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==
+  /browserslist/4.16.1:
+    dependencies:
+      caniuse-lite: 1.0.30001179
+      colorette: 1.2.1
+      electron-to-chromium: 1.3.642
+      escalade: 3.1.1
+      node-releases: 1.1.70
+    dev: true
+    engines:
+      node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
+    hasBin: true
+    resolution:
+      integrity: sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
   /buffer-from/1.1.1:
     dev: true
     resolution:
@@ -2440,6 +2427,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-p/PO5YbwmCpBJPxjOiKBvAlUPgF8dExhfEpnsH+ys4N/791WHrYrGg0cyHiAURl5hSbx5vIcjKmQAP6sHDYH3w==
+  /caniuse-lite/1.0.30001179:
+    dev: true
+    resolution:
+      integrity: sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
   /caseless/0.12.0:
     dev: true
     resolution:
@@ -2653,6 +2644,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+  /colorette/1.2.1:
+    dev: true
+    resolution:
+      integrity: sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
   /colors/1.0.3:
     dev: true
     engines:
@@ -2754,20 +2749,20 @@ packages:
     optional: true
     resolution:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
-  /core-js-compat/3.6.5:
+  /core-js-compat/3.8.3:
     dependencies:
-      browserslist: 4.14.5
+      browserslist: 4.16.1
       semver: 7.0.0
     dev: true
     resolution:
-      integrity: sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
+      integrity: sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==
   /core-js-pure/3.6.5:
     dev: true
     requiresBuild: true
     resolution:
       integrity: sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
   /core-js/2.6.11:
-    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: true
     requiresBuild: true
     resolution:
@@ -2788,7 +2783,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
-  /cross-env/7.0.2:
+  /cross-env/7.0.3:
     dependencies:
       cross-spawn: 7.0.3
     dev: true
@@ -2798,7 +2793,7 @@ packages:
       yarn: '>=1'
     hasBin: true
     resolution:
-      integrity: sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
+      integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   /cross-spawn/7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -3062,6 +3057,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-dSb64JQSFif/pD8mpVAgSFkbVi6YHbK6JeEziwNNmXlr/Ne2rZtseFK5SM7JoWSLf6gP0gVvRGi4/2ZRhSX/rA==
+  /electron-to-chromium/1.3.642:
+    dev: true
+    resolution:
+      integrity: sha512-cev+jOrz/Zm1i+Yh334Hed6lQVOkkemk2wRozfMF4MtTR7pxf3r3L5Rbd7uX1zMcEqVJ7alJBnJL7+JffkC6FQ==
   /emoji-regex/7.0.3:
     dev: true
     resolution:
@@ -3176,6 +3175,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
+  /escalade/3.1.1:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
   /escape-goat/2.1.1:
     dev: true
     engines:
@@ -4843,20 +4848,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
-  /leven/3.1.0:
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-  /levenary/1.1.1:
-    dependencies:
-      leven: 3.1.0
-    dev: true
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   /levn/0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5248,6 +5239,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==
+  /node-releases/1.1.70:
+    dev: true
+    resolution:
+      integrity: sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
   /nopt/4.0.3:
     dependencies:
       abbrev: 1.1.1
@@ -6170,7 +6165,7 @@ packages:
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    deprecated: 'request has been deprecated, see https://github.com/request/request/issues/3142'
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     dev: true
     engines:
       node: '>= 6'
@@ -6199,7 +6194,7 @@ packages:
     resolution:
       integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
   /resolve-url/0.2.1:
-    deprecated: 'https://github.com/lydell/resolve-url#deprecated'
+    deprecated: https://github.com/lydell/resolve-url#deprecated
     dev: true
     optional: true
     resolution:
@@ -7208,7 +7203,7 @@ packages:
     resolution:
       integrity: sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
   /urix/0.1.0:
-    deprecated: 'Please see https://github.com/lydell/urix#deprecated'
+    deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
     optional: true
     resolution:

--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -3,16 +3,10 @@
 
 .datatip-element {
   overflow: auto; // prevents the long text to come out of the datatip
-  background: @app-background-color;
-  box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 1);
   color: @syntax-text-color;
-  margin-top: -2px; // Compensate for shadow
-  position: relative;
   white-space: nowrap;
   pointer-events: all; // hyperlinks will work
   // user-select: text;   // allow selecting text // TODO does not work
-
-  padding: 5px 5px 2px 5px;
 
   font-family: var(--editor-font-family);
   font-size: var(--editor-font-size);
@@ -37,6 +31,10 @@
       margin-bottom: 8px;
     }
   }
+}
+
+.datatip-element.select-list.popover-list {
+  width: auto;
 }
 
 .datatip-element.datatip-glow {


### PR DESCRIPTION
No idea why, but it keeps rejecting my pushes to branches, so I had to fork.

The datatip looks a bit rough with its shadow and sharp corners, the Autocomplete popover looks much cleaner, imho. This will add the necessary classes to the datatip to make it look like Autocomplete. This can also potentially help with the theming, not sure.

<details>
  <summary>Before:</summary>
  <img src="https://user-images.githubusercontent.com/15035286/105493098-fb589300-5cc9-11eb-8e80-25d4b550325e.png"></img>
</details>

<details>
  <summary>After:</summary>
  <img src="https://user-images.githubusercontent.com/15035286/105493121-027fa100-5cca-11eb-8c92-ffa92567a025.png"></img>
</details>

This will also update the lockfile.

