### PR TITLE
feat: use gray color for datatips (doc category)

### DIFF
--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -52,7 +52,7 @@
   // the resizable
 
   // info border
-  border-bottom: 2px solid @background-color-info;
+  border-bottom: 5px solid @background-color-highlight;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
Since datatips are documentation, we can introduce a doc color category and use that instead blue which means `info`.