### PR TITLE
fix: Update atom-package-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "atom-ide-base": "^2.3.4",
-    "atom-package-deps": "^7.2.0"
+    "atom-package-deps": "^7.2.1"
   },
   "devDependencies": {
     "@types/atom": "^1.40.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 dependencies:
   atom-ide-base: 2.3.4
-  atom-package-deps: 7.2.0
+  atom-package-deps: 7.2.1
 devDependencies:
   '@types/atom': 1.40.7
   '@types/jasmine': 3.6.3
@@ -949,7 +949,7 @@ packages:
   /atom-ide-base/2.3.4:
     dependencies:
       atom-ide-markdown-service: 2.0.0
-      atom-package-deps: 7.2.0
+      atom-package-deps: 7.2.1
       classnames: 2.2.6
       dompurify: 2.2.6
       etch: 0.14.1
@@ -1003,11 +1003,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-/K3ulisvui/sKMvx4WYEgJ/1oSzg8Jz6uujYlCwbyB0/jhS+a9JVkKY0yJNb2nbaT6XA4eluBi3CTQM4lJnkLQ==
-  /atom-package-deps/7.2.0:
+  /atom-package-deps/7.2.1:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-P7XnvYv+qYjFrdWWOuRCJ2oOe6Ps0DinwUhJ+h4Zwk/VGStO/x23A/tBDCWyvsZFwEfgGnnhTY+jZ7/pCxxYng==
+      integrity: sha512-Bp+TosS8t8FHZU9TeJIKJ9fDb0gMILCc6WCJQfhOCW0ZfGqBVLa5VzJhENBT3iHiDojWkc7o4BJUYNyptn8VtQ==
   /aws-sign2/0.7.0:
     dev: true
     resolution:
@@ -5495,7 +5495,7 @@ specifiers:
   atom-ide-base: ^2.3.4
   atom-jasmine3-test-runner: ^5.1.8
   atom-languageclient: ^1.0.6
-  atom-package-deps: ^7.2.0
+  atom-package-deps: ^7.2.1
   build-commit: ^0.1.4
   cross-env: latest
   eslint: 7.19.0


### PR DESCRIPTION
Fixes installing Atom package dependencies when `apm` has a space in its install path.

See: https://github.com/steelbrain/package-deps/pull/331