### PR TITLE
Bump atom-package-deps with Windows spaced-path fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "atom-ide-base": "^2.3.4",
-    "atom-package-deps": "^7.2.0"
+    "atom-package-deps": "^7.2.2"
   },
   "devDependencies": {
     "@types/atom": "^1.40.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 dependencies:
   atom-ide-base: 2.3.4
-  atom-package-deps: 7.2.0
+  atom-package-deps: 7.2.2
 devDependencies:
   '@types/atom': 1.40.7
   '@types/jasmine': 3.6.3
@@ -1008,6 +1008,11 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-P7XnvYv+qYjFrdWWOuRCJ2oOe6Ps0DinwUhJ+h4Zwk/VGStO/x23A/tBDCWyvsZFwEfgGnnhTY+jZ7/pCxxYng==
+  /atom-package-deps/7.2.2:
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-xV4l1Ll987zluBjMiYGtDbZbdM5PF/hOECgaI2mv2+dNzbuugd2M+A2liw1JUenuGrngGw/wcpPqXpAVMGFeDw==
   /aws-sign2/0.7.0:
     dev: true
     resolution:
@@ -5495,7 +5500,7 @@ specifiers:
   atom-ide-base: ^2.3.4
   atom-jasmine3-test-runner: ^5.1.8
   atom-languageclient: ^1.0.6
-  atom-package-deps: ^7.2.0
+  atom-package-deps: ^7.2.2
   build-commit: ^0.1.4
   cross-env: latest
   eslint: 7.19.0


### PR DESCRIPTION
Bumps atom-package-deps to version 7.2.2 to work properly on Windows when paths contain spaces.

Specifically this time busy-signal fails to install because the version in atom-ide-datatip was not bumped. Part of our previous PRs, I start clean everytime to ensure installation for windows with spaced paths works on a clean workspace with no packages (because if busy-signal happened to be installed on the workspace already, it wouldn't fail installing)