### PR TITLE
fix: add type defs for react

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "rollup-plugin-atomic": "^2.0.1",
     "shx": "^0.3.3",
     "tslib": "^2.1.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "@types/react": "^17.0.1",
+    "@types/react-dom": "^17.0.0"
   },
   "atomTestRunner": "./spec/runner",
   "activationHooks": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ devDependencies:
   '@types/atom': 1.40.7
   '@types/jasmine': 3.6.3
   '@types/node': 14.14.25
+  '@types/react': 17.0.2
+  '@types/react-dom': 17.0.1
   atom-jasmine3-test-runner: 5.1.8
   atom-languageclient: 1.0.6
   build-commit: 0.1.4
@@ -586,6 +588,23 @@ packages:
     dev: true
     resolution:
       integrity: sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==
+  /@types/prop-types/15.7.3:
+    dev: true
+    resolution:
+      integrity: sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+  /@types/react-dom/17.0.1:
+    dependencies:
+      '@types/react': 17.0.2
+    dev: true
+    resolution:
+      integrity: sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
+  /@types/react/17.0.2:
+    dependencies:
+      '@types/prop-types': 15.7.3
+      csstype: 3.0.6
+    dev: true
+    resolution:
+      integrity: sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
   /@types/resolve/1.17.1:
     dependencies:
       '@types/node': 14.14.2
@@ -1589,6 +1608,10 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==
+  /csstype/3.0.6:
+    dev: true
+    resolution:
+      integrity: sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
   /damerau-levenshtein/1.0.6:
     dev: true
     resolution:
@@ -5492,6 +5515,8 @@ specifiers:
   '@types/atom': ^1.40.7
   '@types/jasmine': ^3.6.3
   '@types/node': ^14.14.25
+  '@types/react': ^17.0.1
+  '@types/react-dom': ^17.0.0
   atom-ide-base: ^2.3.4
   atom-jasmine3-test-runner: ^5.1.8
   atom-languageclient: ^1.0.6


### PR DESCRIPTION
This adds `@types/react & @types/react-dom` to devDeps. `npm run build` would fail otherwise having not knowing info about react types.