### PR TITLE
feat: replace glow effect with bottom-bar glow effect

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -16,11 +16,5 @@
     "description": "The time that the mouse/cursor should hover/stay to show a datatip. Also specifies the time that the datatip is still shown when the mouse/cursor moves [ms].",
     "type": "number",
     "default": 100
-  },
-  "glowOnHover": {
-    "title": "Glow on hover",
-    "description": "Should the datatip glow when you hover on it?",
-    "type": "boolean",
-    "default": true
   }
 }

--- a/lib/datatip-manager.ts
+++ b/lib/datatip-manager.ts
@@ -368,7 +368,7 @@ export class DataTipManager {
               containerClassName: "datatip-component-container",
               contentClassName: "datatip-component",
             },
-            className: "datatip-element select-list popover-list datatip-transform",
+            className: "datatip-element select-list popover-list",
           })
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)
         } else if (datatip.markedStrings.length > 0) {
@@ -406,7 +406,7 @@ export class DataTipManager {
           const dataTipView = new ViewContainer({
             snippet,
             markdown,
-            className: "datatip-element select-list popover-list datatip-transform",
+            className: "datatip-element select-list popover-list",
           })
 
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)

--- a/lib/datatip-manager.ts
+++ b/lib/datatip-manager.ts
@@ -79,9 +79,6 @@ export class DataTipManager {
   /** The time that the mouse/cursor should hover/stay to show a datatip. Also specifies the time that the datatip is still shown when the mouse/cursor moves [ms]. */
   hoverTime = atom.config.get("atom-ide-datatip.hoverTime")
 
-  // glow on hover
-  glowClass = atom.config.get("atom-ide-datatip.glowOnHover") ? "datatip-glow" : ""
-
   constructor() {
     /**
      * the mouse move event handler that evaluates the screen position and eventually shows a data tip
@@ -371,7 +368,7 @@ export class DataTipManager {
               containerClassName: "datatip-component-container",
               contentClassName: "datatip-component",
             },
-            className: `datatip-element select-list popover-list ${this.glowClass}`,
+            className: "datatip-element select-list popover-list datatip-transform",
           })
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)
         } else if (datatip.markedStrings.length > 0) {
@@ -409,7 +406,7 @@ export class DataTipManager {
           const dataTipView = new ViewContainer({
             snippet,
             markdown,
-            className: `datatip-element select-list popover-list ${this.glowClass}`,
+            className: "datatip-element select-list popover-list datatip-transform",
           })
 
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)

--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -38,7 +38,7 @@
   width: auto;
 }
 
-.datatip-element.datatip-glow {
+.datatip-element.datatip-transform {
   // glow on hover
   transition: background-color 0.15s ease;
   &:hover {

--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -38,18 +38,16 @@
   width: auto;
 }
 
-.datatip-element.datatip-transform {
-  // glow on hover
-  transition: background-color 0.15s ease;
-  &:hover {
-    background-color: mix(@syntax-background-color, @syntax-selection-color, 95%);
-  }
-}
-
 .datatip-overlay {
   // info border
   border-bottom: 5px solid @background-color-highlight;
   border-radius: 3px;
+
+  // info bar glow
+  transition: border-bottom-color 0.15s ease;
+  &:hover {
+    border-bottom-color: lighten(@background-color-highlight, 10%);
+  }
 }
 
 /** Applied to ReactView (Components) */


### PR DESCRIPTION
Now only the bottom bar glows instead of the whole datatip.


Closes https://github.com/atom-community/atom-ide-datatip/issues/107
![transform-info](https://user-images.githubusercontent.com/16418197/109386147-65aeb580-78be-11eb-801c-b082347db9dc.gif)
![transform-info-light](https://user-images.githubusercontent.com/16418197/109386148-66474c00-78be-11eb-9254-aba349ccc920.gif)
