### PR TITLE
feat: make datatips look like the linter tooltips

### DIFF
--- a/lib/datatip-manager.ts
+++ b/lib/datatip-manager.ts
@@ -361,7 +361,7 @@ export class DataTipManager {
               containerClassName: "datatip-component-container",
               contentClassName: "datatip-component",
             },
-            className: "datatip-element select-list popover-list",
+            className: "datatip-element",
           })
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)
         } else if (datatip.markedStrings.length > 0) {
@@ -399,7 +399,7 @@ export class DataTipManager {
           const dataTipView = new ViewContainer({
             snippet,
             markdown,
-            className: "datatip-element select-list popover-list",
+            className: "datatip-element",
           })
 
           this.dataTipMarkerDisposables = this.mountDataTipWithMarker(editor, datatip.range, position, dataTipView)
@@ -425,7 +425,10 @@ export class DataTipManager {
     position: Point,
     view: ViewContainer
   ): CompositeDisposable | null {
-    const element = view.element as HTMLElement
+    const element = document.createElement("div")
+    element.className = "datatip-border"
+
+    element.appendChild(view.element as HTMLElement)
 
     // TODO do we need this?
     if (!element) {

--- a/styles/atom-ide-datatips.less
+++ b/styles/atom-ide-datatips.less
@@ -1,7 +1,19 @@
 @import "ui-variables";
 @import "syntax-variables";
 
+// .datatip-overlay {
+// }
+
+.datatip-border {
+  background: @app-background-color;
+  padding: 10px;
+}
+
 .datatip-element {
+  background: @app-background-color;
+  .datatip-hover-effect();
+  padding: 2px;
+
   overflow: auto; // prevents the long text to come out of the datatip
   color: @syntax-text-color;
   white-space: nowrap;
@@ -34,19 +46,14 @@
   }
 }
 
-.datatip-element.select-list.popover-list {
-  width: auto;
-}
-
-.datatip-overlay {
+.datatip-hover-effect() {
   // info border
-  border-bottom: 5px solid @background-color-highlight;
-  border-radius: 3px;
+  border-left: 5px solid @background-color-highlight;
 
   // info bar glow
-  transition: border-bottom-color 0.15s ease;
+  transition: border-left-color 0.15s ease;
   &:hover {
-    border-bottom-color: lighten(@background-color-highlight, 10%);
+    border-left-color: lighten(@background-color-highlight, 10%);
   }
 }
 


### PR DESCRIPTION
May fix #117

It looks like linter tooltips on markdown/snippet datatips:

![image](https://user-images.githubusercontent.com/16418197/111721111-422bba80-882d-11eb-8b71-9e10ca4e3235.png)

![image](https://user-images.githubusercontent.com/16418197/111721255-7ef7b180-882d-11eb-8777-7683c117025a.png)

But on more react components, the left border looks quite bad:

![image](https://user-images.githubusercontent.com/16418197/111721191-64253d00-882d-11eb-92f3-1a682a3bb536.png)
